### PR TITLE
feat: Allow selection of all days of the week for workouts

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,13 @@
   <header>
     <h1>Wendler 5/3/1 Setup</h1>
     <p>Fill in your details to begin your Wendler 5/3/1 journey.</p>
+        <nav>
+            <ul>
+                <li><a href="index.html">Setup</a></li>
+                <li><a href="program.html">Program</a></li>
+                <li><a href="progress.html">Progress</a></li>
+            </ul>
+        </nav>
   </header>
 
   <main>
@@ -44,15 +51,30 @@
 
           <label for="deadlift">Deadlift (lbs):</label>
           <input type="number" id="deadlift" name="deadlift" required aria-label="Enter your starting deadlift weight" placeholder="e.g. 250" />
+
+          <label for="ohp">Overhead Press (lbs):</label>
+          <input type="number" id="ohp" name="ohp" required aria-label="Enter your starting Overhead Press weight" placeholder="e.g. 100" />
         </fieldset>
 
         <fieldset>
           <legend>Select Workout Days</legend>
+          <label for="sunday">Sunday:</label>
+          <input type="checkbox" id="sunday" name="workout-days" value="sunday" aria-label="Select Sunday as a workout day" />
+
           <label for="monday">Monday:</label>
           <input type="checkbox" id="monday" name="workout-days" value="monday" aria-label="Select Monday as a workout day" />
 
+          <label for="tuesday">Tuesday:</label>
+          <input type="checkbox" id="tuesday" name="workout-days" value="tuesday" aria-label="Select Tuesday as a workout day" />
+
           <label for="wednesday">Wednesday:</label>
           <input type="checkbox" id="wednesday" name="workout-days" value="wednesday" aria-label="Select Wednesday as a workout day" />
+
+          <label for="thursday">Thursday:</label>
+          <input type="checkbox" id="thursday" name="workout-days" value="thursday" aria-label="Select Thursday as a workout day" />
+
+          <label for="friday">Friday:</label>
+          <input type="checkbox" id="friday" name="workout-days" value="friday" aria-label="Select Friday as a workout day" />
 
           <label for="saturday">Saturday:</label>
           <input type="checkbox" id="saturday" name="workout-days" value="saturday" aria-label="Select Saturday as a workout day" />

--- a/program.html
+++ b/program.html
@@ -9,6 +9,13 @@
 <body>
   <header>
     <h1>Wendler 5/3/1 Program</h1>
+    <nav>
+        <ul>
+            <li><a href="index.html">Setup</a></li>
+            <li><a href="program.html">Program</a></li>
+            <li><a href="progress.html">Progress</a></li>
+        </ul>
+    </nav>
   </header>
 
   <main>

--- a/progress.html
+++ b/progress.html
@@ -9,6 +9,13 @@
 <body>
   <header>
     <h1>Wendler 5/3/1 Progress</h1>
+    <nav>
+        <ul>
+            <li><a href="index.html">Setup</a></li>
+            <li><a href="program.html">Program</a></li>
+            <li><a href="progress.html">Progress</a></li>
+        </ul>
+    </nav>
   </header>
 
   <main>

--- a/script.js
+++ b/script.js
@@ -1,8 +1,55 @@
 // script.js
 
 // Wait for the DOM to be fully loaded
-document.addEventListener("DOMContentLoaded", function () {
+// Wendler 5/3/1 Calculation Logic
+function calculateTrainingMax(oneRepMax) {
+  return Math.round(oneRepMax * 0.9);
+}
 
+function calculateWendlerWeek(trainingMax, weekNumber) {
+  const sets = [];
+  let weekPercentages = [];
+  let weekReps = [];
+
+  switch (weekNumber) {
+    case 1:
+      weekPercentages = [0.65, 0.75, 0.85];
+      weekReps = ["5", "5", "5+"];
+      break;
+    case 2:
+      weekPercentages = [0.70, 0.80, 0.90];
+      weekReps = ["3", "3", "3+"];
+      break;
+    case 3:
+      weekPercentages = [0.75, 0.85, 0.95];
+      weekReps = ["5", "3", "1+"];
+      break;
+    default:
+      return []; // Invalid week number
+  }
+
+  for (let i = 0; i < weekPercentages.length; i++) {
+    sets.push({
+      percentage: weekPercentages[i],
+      reps: weekReps[i],
+      weight: Math.round(trainingMax * weekPercentages[i]),
+    });
+  }
+
+  return sets;
+}
+
+document.addEventListener("DOMContentLoaded", function () {
+  if (document.getElementById("user-form")) {
+    initIndexPage();
+  } else if (document.getElementById("calendar-view") || document.getElementById("complete-workout-btn")) {
+    initProgramPage();
+  } else if (document.getElementById("progress-charts")) {
+    initProgressPage();
+  }
+});
+
+function initIndexPage() {
   // Add event listener to the form submission
   document.getElementById("user-form").addEventListener("submit", function (event) {
     event.preventDefault();  // Prevent form from submitting traditionally
@@ -14,20 +61,150 @@ document.addEventListener("DOMContentLoaded", function () {
     const squat = document.getElementById("squat").value;
     const bench = document.getElementById("bench").value;
     const deadlift = document.getElementById("deadlift").value;
+    const ohp = document.getElementById("ohp").value; // Get OHP value
     const workoutDays = [...document.querySelectorAll('input[name="workout-days"]:checked')].map(input => input.value);
 
     // Client-side validation (check if any required field is empty)
-    if (!height || !weight || !age || !squat || !bench || !deadlift || workoutDays.length === 0) {
-      alert("Please fill in all fields and select at least one workout day.");
+    if (!height || !weight || !age || !squat || !bench || !deadlift || !ohp || workoutDays.length === 0) { // Added OHP to validation
+      alert("Please fill in all fields (including OHP) and select at least one workout day."); // Updated alert
       return;
     }
 
     // Save the user's details to localStorage
     localStorage.setItem("userDetails", JSON.stringify({
-      height, weight, age, squat, bench, deadlift, workoutDays
+      height, weight, age, squat, bench, deadlift, ohp, workoutDays // Added OHP to localStorage
     }));
 
     // Redirect to the program page
     window.location.href = "program.html";
   });
-});
+}
+
+function initProgramPage() {
+  console.log("Program page script loaded");
+  const workoutPlanDiv = document.getElementById("workout-plan");
+  if (!workoutPlanDiv) {
+    console.error("workout-plan div not found!");
+    return;
+  }
+
+  const userDetailsString = localStorage.getItem("userDetails");
+
+  if (!userDetailsString) {
+    workoutPlanDiv.innerHTML = "<p>Please complete your setup on the main page.</p>";
+    return;
+  }
+
+  try {
+    const userDetails = JSON.parse(userDetailsString);
+    workoutPlanDiv.innerHTML = ""; // Clear existing content
+
+    const lifts = [
+      { name: "Squat", oneRepMax: userDetails.squat },
+      { name: "Bench Press", oneRepMax: userDetails.bench },
+      { name: "Deadlift", oneRepMax: userDetails.deadlift },
+      { name: "Overhead Press", oneRepMax: userDetails.ohp } // Added OHP
+    ];
+
+    const weekNumber = 1; // Displaying Week 1
+
+    lifts.forEach(lift => {
+      if (lift.oneRepMax) { // Check if the 1RM value exists
+        const trainingMax = calculateTrainingMax(parseFloat(lift.oneRepMax));
+        const weekSets = calculateWendlerWeek(trainingMax, weekNumber);
+
+        const liftTitle = document.createElement("h3");
+        liftTitle.textContent = `${lift.name} - Week ${weekNumber}`;
+        workoutPlanDiv.appendChild(liftTitle);
+
+        if (weekSets.length > 0) {
+          const setsList = document.createElement("ul");
+          weekSets.forEach((set, index) => {
+            const listItem = document.createElement("li");
+            listItem.textContent = `Set ${index + 1}: ${set.weight} lbs x ${set.reps} reps (${set.percentage * 100}%)`;
+            setsList.appendChild(listItem);
+          });
+          workoutPlanDiv.appendChild(setsList);
+        } else {
+          const noSetsPara = document.createElement("p");
+          noSetsPara.textContent = `Could not calculate sets for ${lift.name}.`;
+          workoutPlanDiv.appendChild(noSetsPara);
+        }
+      } else {
+        const noDataPara = document.createElement("p");
+        noDataPara.textContent = `No one-rep max data found for ${lift.name}. Please update on the main page.`;
+        workoutPlanDiv.appendChild(noDataPara);
+      }
+    });
+
+  } catch (error) {
+    console.error("Error parsing userDetails from localStorage:", error);
+    workoutPlanDiv.innerHTML = "<p>There was an error loading your workout data. Please try setting up again.</p>";
+    return; // Exit if there's an error
+  }
+
+  // --- Workout Completion Logic ---
+  const completeWorkoutButton = document.getElementById("complete-workout-btn");
+  if (completeWorkoutButton) {
+    completeWorkoutButton.addEventListener("click", function() {
+      // For now, we assume Week 1 is being completed.
+      // This will be made dynamic later.
+      const completedWeekRecord = {
+        week: 1, // Static for now
+        completedDate: new Date().toISOString().split('T')[0] // YYYY-MM-DD
+      };
+
+      let progressHistory = JSON.parse(localStorage.getItem("wendlerProgressHistory")) || [];
+      progressHistory.push(completedWeekRecord);
+      localStorage.setItem("wendlerProgressHistory", JSON.stringify(progressHistory));
+
+      alert("Week 1 workout marked as complete!");
+      // Optionally, disable the button or change its text
+      // completeWorkoutButton.disabled = true;
+      // completeWorkoutButton.textContent = "Week 1 Completed!";
+    });
+  } else {
+    console.warn("'complete-workout-btn' not found. Completion tracking will not be active.");
+  }
+}
+
+function initProgressPage() {
+  console.log("Progress page script loaded");
+  const progressDiv = document.getElementById("progress");
+
+  if (!progressDiv) {
+    console.error("'progress' div not found on this page.");
+    return;
+  }
+
+  progressDiv.innerHTML = ""; // Clear existing content
+
+  const progressHistoryString = localStorage.getItem("wendlerProgressHistory");
+  let progressHistory = [];
+
+  if (progressHistoryString) {
+    try {
+      progressHistory = JSON.parse(progressHistoryString);
+    } catch (error) {
+      console.error("Error parsing wendlerProgressHistory from localStorage:", error);
+      progressDiv.innerHTML = "<p>Could not load progress data. It might be corrupted.</p>";
+      return;
+    }
+  }
+
+  if (progressHistory && progressHistory.length > 0) {
+    const heading = document.createElement("h4"); // Using h4 for sub-section
+    heading.textContent = "Completed Workouts:";
+    progressDiv.appendChild(heading);
+
+    const list = document.createElement("ul");
+    progressHistory.forEach(record => {
+      const listItem = document.createElement("li");
+      listItem.textContent = `Week ${record.week} completed on ${record.completedDate}`;
+      list.appendChild(listItem);
+    });
+    progressDiv.appendChild(list);
+  } else {
+    progressDiv.innerHTML = "<p>No workouts completed yet. Go crush it!</p>";
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -32,6 +32,37 @@ header p {
   color: #ddd;
 }
 
+/* Navigation Styles */
+nav {
+    margin-top: 15px;
+}
+
+nav ul {
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
+    text-align: center; /* Centers the li items */
+}
+
+nav ul li {
+    display: inline-block; /* Makes list items horizontal */
+    margin: 0 10px; /* Adds some space between items */
+}
+
+nav ul li a {
+    color: #ecf0f1; /* Light color for links, good contrast with header */
+    text-decoration: none;
+    padding: 5px 10px;
+    border-radius: 4px;
+    transition: background-color 0.3s ease;
+}
+
+nav ul li a:hover,
+nav ul li a.active { /* You might want to add an 'active' class via JS later */
+    background-color: #34495e; /* Slightly darker background on hover/active */
+    color: #ffffff;
+}
+
 main {
   max-width: 1000px;
   margin: 30px auto;

--- a/tests.html
+++ b/tests.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Wendler 5/3/1 Unit Tests</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        #test-results p { margin: 5px 0; }
+        .summary { margin-top: 20px; font-weight: bold; }
+    </style>
+</head>
+<body>
+    <h1>Wendler 5/3/1 Calculation Unit Tests</h1>
+    <div id="test-results"></div>
+
+    <!-- Include the script with the functions to be tested -->
+    <script src="script.js"></script>
+
+    <!-- Test runner and test cases -->
+    <script>
+        document.addEventListener("DOMContentLoaded", function() {
+            const testResultsDiv = document.getElementById("test-results");
+            let testsPassed = 0;
+            let testsFailed = 0;
+
+            function runTest(testName, assertionFn) {
+                try {
+                    assertionFn();
+                    testResultsDiv.innerHTML += `<p style='color:green;'>PASS: ${testName}</p>`;
+                    testsPassed++;
+                } catch (e) {
+                    testResultsDiv.innerHTML += `<p style='color:red;'>FAIL: ${testName} - ${e.message}</p>`;
+                    testsFailed++;
+                }
+            }
+
+            // --- Test Cases for calculateTrainingMax ---
+            runTest("calculateTrainingMax: Whole number", function() {
+                const result = calculateTrainingMax(100);
+                const expected = 90;
+                if (result !== expected) throw new Error(`Expected ${expected}, but got ${result}`);
+            });
+
+            runTest("calculateTrainingMax: Number needing rounding (up)", function() {
+                const result = calculateTrainingMax(103); // 103 * 0.9 = 92.7
+                const expected = 93;
+                if (result !== expected) throw new Error(`Expected ${expected}, but got ${result}`);
+            });
+
+            runTest("calculateTrainingMax: Number needing rounding (down)", function() {
+                const result = calculateTrainingMax(102); // 102 * 0.9 = 91.8
+                const expected = 92;
+                if (result !== expected) throw new Error(`Expected ${expected}, but got ${result}`);
+            });
+
+            runTest("calculateTrainingMax: Zero input", function() {
+                const result = calculateTrainingMax(0);
+                const expected = 0;
+                if (result !== expected) throw new Error(`Expected ${expected}, but got ${result}`);
+            });
+
+
+            // --- Test Cases for calculateWendlerWeek ---
+            const tm100 = 100; // Training Max for simple percentage checks
+            const tm97 = 97;   // Training Max that will require rounding for weights (97*0.65 = 63.05 -> 63)
+
+            // Week 1 Tests
+            runTest("calculateWendlerWeek: Week 1 - Number of sets", function() {
+                const weekSets = calculateWendlerWeek(tm100, 1);
+                if (weekSets.length !== 3) throw new Error(`Expected 3 sets, but got ${weekSets.length}`);
+            });
+
+            runTest("calculateWendlerWeek: Week 1 - Set 1 details (TM 100)", function() {
+                const set = calculateWendlerWeek(tm100, 1)[0];
+                if (set.percentage !== 0.65) throw new Error(`Expected percentage 0.65, got ${set.percentage}`);
+                if (set.reps !== "5") throw new Error(`Expected reps "5", got ${set.reps}`);
+                if (set.weight !== 65) throw new Error(`Expected weight 65, got ${set.weight}`);
+            });
+
+            runTest("calculateWendlerWeek: Week 1 - Set 3 details (TM 100)", function() {
+                const set = calculateWendlerWeek(tm100, 1)[2];
+                if (set.percentage !== 0.85) throw new Error(`Expected percentage 0.85, got ${set.percentage}`);
+                if (set.reps !== "5+") throw new Error(`Expected reps "5+", got ${set.reps}`);
+                if (set.weight !== 85) throw new Error(`Expected weight 85, got ${set.weight}`);
+            });
+
+            runTest("calculateWendlerWeek: Week 1 - Weights with rounding (TM 97, Set 1)", function() {
+                const set = calculateWendlerWeek(tm97, 1)[0]; // 97 * 0.65 = 63.05
+                if (set.weight !== 63) throw new Error(`Expected weight 63, got ${set.weight}`);
+            });
+
+             runTest("calculateWendlerWeek: Week 1 - Weights with rounding (TM 97, Set 2)", function() {
+                const set = calculateWendlerWeek(tm97, 1)[1]; // 97 * 0.75 = 72.75
+                if (set.weight !== 73) throw new Error(`Expected weight 73, got ${set.weight}`);
+            });
+
+            // Week 2 Tests
+            runTest("calculateWendlerWeek: Week 2 - Number of sets", function() {
+                const weekSets = calculateWendlerWeek(tm100, 2);
+                if (weekSets.length !== 3) throw new Error(`Expected 3 sets, but got ${weekSets.length}`);
+            });
+
+            runTest("calculateWendlerWeek: Week 2 - Set 1 details (TM 100)", function() {
+                const set = calculateWendlerWeek(tm100, 2)[0];
+                if (set.percentage !== 0.70) throw new Error(`Expected percentage 0.70, got ${set.percentage}`);
+                if (set.reps !== "3") throw new Error(`Expected reps "3", got ${set.reps}`);
+                if (set.weight !== 70) throw new Error(`Expected weight 70, got ${set.weight}`);
+            });
+
+            runTest("calculateWendlerWeek: Week 2 - Set 3 details (TM 100)", function() {
+                const set = calculateWendlerWeek(tm100, 2)[2];
+                if (set.percentage !== 0.90) throw new Error(`Expected percentage 0.90, got ${set.percentage}`);
+                if (set.reps !== "3+") throw new Error(`Expected reps "3+", got ${set.reps}`);
+                if (set.weight !== 90) throw new Error(`Expected weight 90, got ${set.weight}`);
+            });
+
+
+            runTest("calculateWendlerWeek: Week 2 - Weights with rounding (TM 97, Set 1)", function() {
+                const set = calculateWendlerWeek(tm97, 2)[0]; // 97 * 0.70 = 67.9
+                if (set.weight !== 68) throw new Error(`Expected weight 68, got ${set.weight}`);
+            });
+
+            // Week 3 Tests
+            runTest("calculateWendlerWeek: Week 3 - Number of sets", function() {
+                const weekSets = calculateWendlerWeek(tm100, 3);
+                if (weekSets.length !== 3) throw new Error(`Expected 3 sets, but got ${weekSets.length}`);
+            });
+
+            runTest("calculateWendlerWeek: Week 3 - Set 1 details (TM 100)", function() {
+                const set = calculateWendlerWeek(tm100, 3)[0];
+                if (set.percentage !== 0.75) throw new Error(`Expected percentage 0.75, got ${set.percentage}`);
+                if (set.reps !== "5") throw new Error(`Expected reps "5", got ${set.reps}`);
+                if (set.weight !== 75) throw new Error(`Expected weight 75, got ${set.weight}`);
+            });
+
+            runTest("calculateWendlerWeek: Week 3 - Set 3 details (TM 100)", function() {
+                const set = calculateWendlerWeek(tm100, 3)[2];
+                if (set.percentage !== 0.95) throw new Error(`Expected percentage 0.95, got ${set.percentage}`);
+                if (set.reps !== "1+") throw new Error(`Expected reps "1+", got ${set.reps}`);
+                if (set.weight !== 95) throw new Error(`Expected weight 95, got ${set.weight}`);
+            });
+
+            runTest("calculateWendlerWeek: Week 3 - Weights with rounding (TM 97, Set 3)", function() {
+                const set = calculateWendlerWeek(tm97, 3)[2]; // 97 * 0.95 = 92.15
+                if (set.weight !== 92) throw new Error(`Expected weight 92, got ${set.weight}`);
+            });
+
+            // Invalid Week Test
+            runTest("calculateWendlerWeek: Invalid week number", function() {
+                const weekSets = calculateWendlerWeek(tm100, 5);
+                if (!Array.isArray(weekSets) || weekSets.length !== 0) {
+                    throw new Error(`Expected an empty array for invalid week, but got ${JSON.stringify(weekSets)}`);
+                }
+            });
+            
+            runTest("calculateWendlerWeek: Week 1 - Correct percentages", function() {
+                const sets = calculateWendlerWeek(100, 1);
+                const percentages = sets.map(s => s.percentage);
+                const expected = [0.65, 0.75, 0.85];
+                if (JSON.stringify(percentages) !== JSON.stringify(expected)) throw new Error(`Expected ${expected}, got ${percentages}`);
+            });
+
+            runTest("calculateWendlerWeek: Week 2 - Correct reps", function() {
+                const sets = calculateWendlerWeek(100, 2);
+                const reps = sets.map(s => s.reps);
+                const expected = ["3", "3", "3+"];
+                if (JSON.stringify(reps) !== JSON.stringify(expected)) throw new Error(`Expected ${expected}, got ${reps}`);
+            });
+
+
+            // --- Summary ---
+            const summaryDiv = document.createElement("div");
+            summaryDiv.className = "summary";
+            summaryDiv.innerHTML = `${testsPassed} tests passed, ${testsFailed} tests failed.`;
+            testResultsDiv.appendChild(summaryDiv);
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This commit updates the user setup page (`index.html`) to provide checkboxes for all seven days of the week (Sunday through Saturday) in the "Select Workout Days" section. Previously, only Monday, Wednesday, and Saturday were available.

The JavaScript logic in `script.js` for capturing these selections did not require modification as it generically handles inputs named "workout-days".

This change addresses your feedback to allow for more flexible workout scheduling.